### PR TITLE
Fail build on checkstyle warnings

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,7 @@ jacoco {
 
 checkstyle {
     configFile file("checkstyle.xml")
+    ignoreFailures = false
 }
 
 pmd {

--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -9,7 +9,7 @@
     Description: none
 -->
 <module name="Checker">
-  <property name="severity" value="warning"/>
+  <property name="severity" value="error"/>
   <module name="TreeWalker">
     <module name="SuppressWarningsHolder" />
     <property name="tabWidth" value="4"/>


### PR DESCRIPTION
Forgot to let the build fail on checkstyle warnings in #2. This PR fixes that.

It also sets the severity level of all checks from warning to error. This is needed to make the warnings 'bad enough' for Gradle to fail.