### PR TITLE
Fixing logic bug when writing logs

### DIFF
--- a/src/default-test/java/nl/tudelft/jpacman/fuzzer/JPacmanFuzzer.java
+++ b/src/default-test/java/nl/tudelft/jpacman/fuzzer/JPacmanFuzzer.java
@@ -117,7 +117,7 @@ class JPacmanFuzzer {
             String.format(
                 "%n%b %b %s %s %d %d",
                 player.isAlive(),
-                (player.getKiller() == null),
+                (player.getKiller() != null),
                 player.getDirection(),
                 chosen,
                 game.getLevel().remainingPellets(),


### PR DESCRIPTION
`hasCollided` written in the logs must be true when `player.getKiller() != null`