### PR TITLE
Suppress spotbugs false positive in Java 11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,12 @@ jobs:
       jdk: oraclejdk8
     - script: ./gradlew test
       jdk: oraclejdk9
+    - script: ./gradlew test
+      jdk: oraclejdk11
     - stage: "Static Analysis"
       script: ./gradlew staticAnalysis
       jdk: oraclejdk8
     - script: ./gradlew staticAnalysis
       jdk: oraclejdk9
+    - script: ./gradlew staticAnalysis
+      jdk: oraclejdk11

--- a/src/main/java/nl/tudelft/jpacman/level/MapParser.java
+++ b/src/main/java/nl/tudelft/jpacman/level/MapParser.java
@@ -239,8 +239,10 @@ public class MapParser {
      * @throws IOException
      *             when the resource could not be read.
      */
-    @SuppressFBWarnings(value = "OBL_UNSATISFIED_OBLIGATION",
-                        justification = "try with resources always cleans up")
+    @SuppressFBWarnings(
+        value = {"OBL_UNSATISFIED_OBLIGATION", "RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE"},
+        justification = "try with resources always cleans up / false positive in java 11"
+    )
     public Level parseMap(String mapName) throws IOException {
         try (InputStream boardStream = MapParser.class.getResourceAsStream(mapName)) {
             if (boardStream == null) {

--- a/src/main/java/nl/tudelft/jpacman/sprite/SpriteStore.java
+++ b/src/main/java/nl/tudelft/jpacman/sprite/SpriteStore.java
@@ -1,5 +1,7 @@
 package nl.tudelft.jpacman.sprite;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 import java.awt.image.BufferedImage;
 import java.io.IOException;
 import java.io.InputStream;
@@ -57,6 +59,10 @@ public class SpriteStore {
      * @throws IOException
      *             When the resource could not be loaded.
      */
+    @SuppressFBWarnings(
+        value = "RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE",
+        justification = "false positive in java 11"
+    )
     private Sprite loadSpriteFromResource(String resource) throws IOException {
         try (InputStream input = SpriteStore.class.getResourceAsStream(resource)) {
             if (input == null) {


### PR DESCRIPTION
In Java 11 SpotBugs reports an issue about a redundant nullcheck for try with resources.

Unfortunately, this is a common issue with no fix available:
* https://github.com/spotbugs/spotbugs/issues/259
* https://github.com/spotbugs/spotbugs/issues/756

This PR suppresses the warning.

I've also added JDK 11 to the Travis config (we would have been able to see the error if we/I had done this earlier 😞) .