### PR TITLE
Add `opposite` method to `Direction`

### DIFF
--- a/src/main/java/nl/tudelft/jpacman/board/Direction.java
+++ b/src/main/java/nl/tudelft/jpacman/board/Direction.java
@@ -3,7 +3,7 @@ package nl.tudelft.jpacman.board;
 /**
  * An enumeration of possible directions on a two-dimensional square grid.
  *
- * @author Jeroen Roosen 
+ * @author Jeroen Roosen
  */
 public enum Direction {
 
@@ -68,5 +68,23 @@ public enum Direction {
      */
     public int getDeltaY() {
         return deltaY;
+    }
+
+    /**
+     * @return The direction that is opposite to this direction.
+     */
+    public Direction getOpposite() {
+        switch (this) {
+            case NORTH:
+                return SOUTH;
+            case SOUTH:
+                return NORTH;
+            case WEST:
+                return EAST;
+            case EAST:
+                return WEST;
+            default:
+                throw new IllegalStateException("Received an unknown enum value.");
+        }
     }
 }

--- a/src/main/java/nl/tudelft/jpacman/board/Direction.java
+++ b/src/main/java/nl/tudelft/jpacman/board/Direction.java
@@ -73,7 +73,7 @@ public enum Direction {
     /**
      * @return The direction that is opposite to this direction.
      */
-    public Direction getOpposite() {
+    public Direction opposite() {
         switch (this) {
             case NORTH:
                 return SOUTH;

--- a/src/main/java/nl/tudelft/jpacman/npc/ghost/Clyde.java
+++ b/src/main/java/nl/tudelft/jpacman/npc/ghost/Clyde.java
@@ -1,6 +1,5 @@
 package nl.tudelft.jpacman.npc.ghost;
 
-import java.util.EnumMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -58,18 +57,6 @@ public class Clyde extends Ghost {
     private static final int MOVE_INTERVAL = 250;
 
     /**
-     * A map of opposite directions.
-     */
-    private static final Map<Direction, Direction> OPPOSITES = new EnumMap<>(Direction.class);
-
-    static {
-        OPPOSITES.put(Direction.NORTH, Direction.SOUTH);
-        OPPOSITES.put(Direction.SOUTH, Direction.NORTH);
-        OPPOSITES.put(Direction.WEST, Direction.EAST);
-        OPPOSITES.put(Direction.EAST, Direction.WEST);
-    }
-
-    /**
      * Creates a new "Clyde", a.k.a. "Pokey".
      *
      * @param spriteMap The sprites for this ghost.
@@ -105,7 +92,7 @@ public class Clyde extends Ghost {
         if (path != null && !path.isEmpty()) {
             Direction direction = path.get(0);
             if (path.size() <= SHYNESS) {
-                return Optional.ofNullable(OPPOSITES.get(direction));
+                return Optional.of(direction.getOpposite());
             }
             return Optional.of(direction);
         }

--- a/src/main/java/nl/tudelft/jpacman/npc/ghost/Clyde.java
+++ b/src/main/java/nl/tudelft/jpacman/npc/ghost/Clyde.java
@@ -92,7 +92,7 @@ public class Clyde extends Ghost {
         if (path != null && !path.isEmpty()) {
             Direction direction = path.get(0);
             if (path.size() <= SHYNESS) {
-                return Optional.of(direction.getOpposite());
+                return Optional.of(direction.opposite());
             }
             return Optional.of(direction);
         }

--- a/src/test/java/nl/tudelft/jpacman/board/DirectionTest.java
+++ b/src/test/java/nl/tudelft/jpacman/board/DirectionTest.java
@@ -19,4 +19,20 @@ public class DirectionTest {
         Direction north = Direction.valueOf("NORTH");
         assertThat(north.getDeltaY()).isEqualTo(-1);
     }
+
+    /**
+     * The correct opposite is returned.
+     */
+    @Test
+    void testOpposite() {
+        assertThat(Direction.NORTH.getOpposite()).isEqualTo(Direction.SOUTH);
+    }
+
+    /**
+     * The opposite of the opposite is the original.
+     */
+    @Test
+    void testOppositeTwice() {
+        assertThat(Direction.WEST.getOpposite().getOpposite()).isEqualTo(Direction.WEST);
+    }
 }

--- a/src/test/java/nl/tudelft/jpacman/board/DirectionTest.java
+++ b/src/test/java/nl/tudelft/jpacman/board/DirectionTest.java
@@ -25,7 +25,7 @@ public class DirectionTest {
      */
     @Test
     void testOpposite() {
-        assertThat(Direction.NORTH.getOpposite()).isEqualTo(Direction.SOUTH);
+        assertThat(Direction.NORTH.opposite()).isEqualTo(Direction.SOUTH);
     }
 
     /**
@@ -33,6 +33,6 @@ public class DirectionTest {
      */
     @Test
     void testOppositeTwice() {
-        assertThat(Direction.WEST.getOpposite().getOpposite()).isEqualTo(Direction.WEST);
+        assertThat(Direction.WEST.opposite().opposite()).isEqualTo(Direction.WEST);
     }
 }


### PR DESCRIPTION
When Clyde runs away from the player, it looks up the opposite of the direction it would otherwise have gone in. To find the opposite, Clyde uses a hash map that maps each direction to its opposite. This PR replaces that hash map with a dedicated function in the `Direction` class.

The default branch in the `getOpposite` method is not reachable because it is not possible to instantiate new instances of an enum class, but at the same time the code won't compile without it.