### PR TITLE
Build on trusty

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: trusty
 language: java
 before_install:
   - "export DISPLAY=:99.0"


### PR DESCRIPTION
The current project is already building on Trusty, however new projects don't do this by default.

This change ensures that new repositories based on this repository can be built successfully on Travis.