### PR TITLE
Let static analysis failures result in a warning on GitLab

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -14,3 +14,4 @@ test:
 warnings:
   stage: static-analysis
   script: "./gradlew staticAnalysis"
+  allow_failure: true


### PR DESCRIPTION
Failures of the static analysis job should result in a warning on the build instead of a failure.