### PR TITLE
Clone observers before iterating

### DIFF
--- a/src/main/java/nl/tudelft/jpacman/level/Level.java
+++ b/src/main/java/nl/tudelft/jpacman/level/Level.java
@@ -263,6 +263,8 @@ public class Level {
      * Updates the observers about the state of this level.
      */
     private void updateObservers() {
+        Iterable<LevelObserver> observers = new ArrayList<>(this.observers);
+
         if (!isAnyPlayerAlive()) {
             for (LevelObserver observer : observers) {
                 observer.levelLost();


### PR DESCRIPTION
If an observer deregisters itself in the `levelWon()` or `levelLost()` call, Java may throw a `ConcurrentModificationException` while iterating the list of observers. To prevent this, this PR makes a shallow copy of the list of observers before iterating over it.